### PR TITLE
Upgrade okhttp to version 5.0.0-alpha.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.6.0</version>
+            <version>5.0.0-alpha.11</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades okhttp to 5.0.0-alpha.11 to fix vulnerabilities in current version